### PR TITLE
Bypass SONAR status check

### DIFF
--- a/_documentation/src/docs/documentation/20_setup.adoc
+++ b/_documentation/src/docs/documentation/20_setup.adoc
@@ -36,6 +36,10 @@ Minimal config entries:
 * xref:30_configuration.adoc#gitlab-api-token[gitlab.api.token]
 * xref:30_configuration.adoc#gitlab-external-check-url[gitlab.external.check.url]
 
+Optional config entries:
+
+* xref:30_configuration.adoc#branch-bypass[branch.bypass]
+
 And if you are on prem GitLab and Sonar servers:
 
 * xref:30_configuration.adoc#sonarqube-host[sonarqube.host]

--- a/_documentation/src/docs/documentation/30_configuration.adoc
+++ b/_documentation/src/docs/documentation/30_configuration.adoc
@@ -14,6 +14,7 @@ gitlab.external.check.url=https://company.example.com/u-sonar-status/gitlab
 gitlab.external.check.name=SONAR
 sonarqube.host=https://sonarcloud.io/
 sonarqube.api.token=3bd9fdc773d5a6df3d2a12f8c35ae2b3e13b8944
+branch.bypass=^mr(\\d+)_.+
 ----
 
 You can use any of the https://quarkus.io/guides/config-reference#configuration-sources[Configuration Sources supported by Quarkus] to set the values.
@@ -85,3 +86,11 @@ Specify the name of the check in Gitlab.
 
 * key: `gitlab.external.check.name`
 * default value: `SONAR`
+
+[#branch-bypass]
+=== Quality Gate Bypass - branch pattern
+
+Specify the regex pattern of branches where the Quality Gate must be bypassed. If the source branch name matches the given pattern, Gitlab's external status check is automatically set to green, without the need to query Sonar.
+
+* key: `branch.bypass`
+* No default value

--- a/src/main/java/com/unblu/usonarstatus/service/Service.java
+++ b/src/main/java/com/unblu/usonarstatus/service/Service.java
@@ -47,8 +47,8 @@ public class Service {
 	@ConfigProperty(name = "gitlab.external.check.name", defaultValue = "SONAR")
 	String externalStatusCheckName;
 
-	@ConfigProperty(name = "branch.bypass", defaultValue = "^mr(\\d+)_.+")
-	String bypassBranchPattern;
+	@ConfigProperty(name = "branch.bypass")
+	Optional<String> bypassBranchPattern;
 
 	@ConfigProperty(name = "gitlab.host", defaultValue = "https://gitlab.com")
 	String gitLabHost;
@@ -97,7 +97,9 @@ public class Service {
 			p.gitLabMergeRequestIid = event.getMergeRequestIid();
 			p.gitLabMergeRequestSha = event.getMergeRequestLastCommitSha();
 			p.gitLabExternalStatusCheckId = event.getExternalStatusCheckId();
-			if (event.getMergeRequestSourceBranch().matches(bypassBranchPattern)) {
+
+			if (bypassBranchPattern.isPresent()
+					&& event.getMergeRequestSourceBranch().matches(bypassBranchPattern.get())) {
 				setExternalCheckStatus(result, p, Status.PASSED);
 			} else {
 				String projectKey = PROJECT_PREFIX + event.getProjectId();

--- a/src/test/java/com/unblu/usonarstatus/USonarStatusTest.java
+++ b/src/test/java/com/unblu/usonarstatus/USonarStatusTest.java
@@ -357,6 +357,35 @@ class USonarStatusTest {
 	}
 
 	@Test
+	void testGitLabBypassCase() throws Exception {
+		wireMockHelper.setupDefaultStubsCommon();
+		GitLabEventSimple simpleGitLabEvent = MockUtil.createDefaultGitLabEventSimple();
+		simpleGitLabEvent.setMergeRequestSourceBranch("mr123_release/6.x.x");
+
+		given().when()
+				.header("Content-Type", "application/json")
+				.body(simpleGitLabEvent)
+				.post("/u-sonar-status/gitlab-replay")
+				.then()
+				.statusCode(Response.Status.OK.getStatusCode())
+				.body(startsWith("{\n"))
+				.body(endsWith("\n}"))
+				.body("build_commit", equalTo("6af21ad"))
+				.body("build_timestamp", equalTo("2022-01-01T07:21:58.378413Z"))
+				.body("source", equalTo("GITLAB"))
+				.body("sonar_event_uuid", nullValue())
+				.body("gitlab_event_uuid", notNullValue())
+				.body("gitlab_project_id", equalTo(56))
+				.body("gitlab_merge_request_iid", equalTo(19))
+				.body("gitlab_external_status_check_id", equalTo(3))
+				.body("gitlab_external_status_check_status", equalTo("passed"))
+				.body("gitlab_external_status_check_status_id", equalTo(4))
+				.body("error", nullValue());
+
+		wireMockHelper.verifyRequests(2);
+	}
+
+	@Test
 	void testGitlabEndpointRapidReturnMalformedRequest() throws Exception {
 		String json = """
 				{

--- a/src/test/java/com/unblu/usonarstatus/util/WireMockHelper.java
+++ b/src/test/java/com/unblu/usonarstatus/util/WireMockHelper.java
@@ -60,12 +60,15 @@ public class WireMockHelper {
 
 	public void setupDefaultStubsForSonar() {
 		setupGetMr();
-		setupGetExternalStatusChecks();
-		setupSetStatusOfExternalStatusCheck();
+		setupDefaultStubsCommon();
 	}
 
 	public void setupDefaultStubsForGitLab() {
 		setupGetSonarPullRequests();
+		setupDefaultStubsCommon();
+	}
+
+	public void setupDefaultStubsCommon() {
 		setupGetExternalStatusChecks();
 		setupSetStatusOfExternalStatusCheck();
 	}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,4 @@ build.commit=6af21ad
 gitlab.api.token=gitlab_token_used_in_unit_tests_1234
 gitlab.external.check.url=https://company.example.com/u-sonar-status/gitlab
 sonarqube.api.token=sonar_token_used_in_unit_tests_9876
+branch.bypass=^mr(\\d+)_.+


### PR DESCRIPTION
Bypass SONAR status check

If the source-branch matches a given pattern, the SONAR status check is bypassed and the GITLAB external check is set to PASSED.