### PR TITLE
Add "quarkus-googlecloud-jsonlogging" extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-container-image-jib'
     implementation 'io.quarkus:quarkus-arc'
+    implementation 'eu.mulk.quarkus-googlecloud-jsonlogging:quarkus-googlecloud-jsonlogging:6.0.0'
     implementation 'org.gitlab4j:gitlab4j-api:5.1.0'
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
@@ -73,6 +74,9 @@ build.timestamp=${java.time.Instant.now().toString()}
 
 quarkus.index-dependency.gitlab4j.group-id=org.gitlab4j
 quarkus.index-dependency.gitlab4j.artifact-id=gitlab4j-api
+
+%dev.quarkus.log.console.google=false
+%test.quarkus.log.console.google=false
 """
     }
 }


### PR DESCRIPTION
Add the extension from project https://github.com/benkard/quarkus-googlecloud-jsonlogging in order to produce logs in the JSON format that is compatible with GCP.

For test and dev mode, the json format it not enabled.
