### PR TITLE
Version based on the commit sha instead of "1.0.0-SNAPSHOT"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 }
 
 group 'com.unblu.usonarstatus'
+version 'rev_' + grgit.head().abbreviatedId
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@ quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformVersion=2.16.6.Final
 
 name=u-sonar-status
-version=1.0.0-SNAPSHOT


### PR DESCRIPTION
For the time being we do not plan to release this tool or use any version semantic.
We just want to build each commit on the `main` branch.

Therefore the current version name `1.0.0-SNAPSHOT` is not used.

The only place where it appears is in a log entry during startup:

```
u-sonar-status 1.0.0-SNAPSHOT on JVM (powered by Quarkus 2.16.6.Final) started in 3.889s. Listening on: http://0.0.0.0:8080
```

This PR changes the version scheme to be `rev_<short commit sha>`.

Example: `rev_f49309d` for commit f49309dbe6371b57d33ee1a3cd806d5e00712db2.